### PR TITLE
Caddy配置文件 第二种反代方式 自动生成证书

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,8 @@
+https://jd.pypy.moe {
+    tls internal
+    reverse_proxy localhost:5000
+}
+
+http://jd.pypy.moe {
+    reverse_proxy localhost:5000
+}


### PR DESCRIPTION
比第一种反代方式更加简单，但还是需要手动添加hosts